### PR TITLE
past event listing sorting issues

### DIFF
--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -9,6 +9,8 @@
   <table class='table table-condensed' id='table-<%= rtid %>'>
     <thead>
       <tr>
+        <th>Date</th>
+        <th>Event Type</th>
         <th>Event</th>
         <th>Action</th>
       </tr>
@@ -17,9 +19,13 @@
       <% events.each do |event| %>
       <tr>
         <td>
-          <span class='label label-info'><%= event.event_type.name %></span>
           <strong><u><%= event.start_time.strftime("%Y-%m-%d") %></u></strong> &nbsp;
           <%= link_to event_path(event), :style => 'text-decoration: none' do %>
+        </td>
+        <td>
+          <span class='label label-info'><%= event.event_type.name %></span>
+        </td>
+        <td>
             <strong><%= truncate(event.descriptive_name, :length => 60) %></strong>
           <% end %>
           <span class='label label-success'><%= link_to event.chapter.name, chapter_path(event.chapter), :style => 'text-decoration: none; color: inherit;' %></span>
@@ -53,6 +59,6 @@
 <%= render partial: 'shared/datatable' %>
 <% if local_assigns[:enable_datatable] %>
   <script>
-    $('#table-<%= rtid %>').DataTable({});
+    $('#table-<%= rtid %>').DataTable({"order": [[ 0, "desc" ]]});
   </script>
 <% end %>


### PR DESCRIPTION
sorting issue in past event listing.

This should ideally fix https://github.com/null-open-security-community/swachalit/issues/66 

The problem understanding: We are using jquery datatable and it can sort data by columns but we were using an aggregation column and hence things would have been difficult to sort. by seperating event type and event date we are able to exert better control over the entries.


Testing was not possible on local system due to limitations imposed by https://github.com/null-open-security-community/swachalit/issues/70 

However based on the issue understanding this should fix things. 
